### PR TITLE
Remove ignoring `.github/workflows/**` for release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
       - main
     paths-ignore:
       - 'README.md'
-      - '.github/workflows/**'
 
 jobs:
   release:


### PR DESCRIPTION
Because of this, the release workflow for https://github.com/steffen/git-metrics/commit/50c7c4ba5e2fa6b0b8b81f76be9f6db286121284 didn't run.