### PR TITLE
Add support running on bare repositories

### DIFF
--- a/.copilot-instructions.md
+++ b/.copilot-instructions.md
@@ -1,0 +1,1 @@
+- Don't use abbreviations in the codebase. For example, use `user` instead of `usr`.

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Binary
-git-metrics
+git-metrics*
 
 # Editor files
 .vscode/launch.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 # Binary
 git-metrics
+
+# Editor files
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 git-metrics
 
 # Editor files
-.vscode
+.vscode/launch.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "github.copilot.chat.codeGeneration.instructions": [
+    {
+      "file": ".copilot-instructions.md"
+    }
+  ],
+  "cSpell.words": [
+    "machdep",
+    "memsize"
+  ]
+}

--- a/main.go
+++ b/main.go
@@ -72,7 +72,7 @@ func main() {
 	fmt.Printf("\033[1A\033[2KGit directory              %s\n", gitDir)
 
 	// Get fetch time before deciding whether to show last modified time
-	recentFetch := git.GetLastFetchTime()
+	recentFetch := git.GetLastFetchTime(gitDir)
 	if recentFetch == "" {
 		fmt.Printf("Last modified              %s\n", lastModified)
 	}

--- a/main.go
+++ b/main.go
@@ -59,6 +59,9 @@ func main() {
 	absolutePath, _ := filepath.Abs(".")
 	fmt.Printf("Path                       %s\n", absolutePath)
 
+	// Check if repository is bare
+	isBare := git.IsBareRepository(".")
+
 	// Remote URL
 	fmt.Printf("Remote                     ... fetching\n")
 	remoteOutput, err := git.RunGitCommand(debug, "remote", "get-url", "origin")
@@ -69,10 +72,17 @@ func main() {
 	// Replace the fetching line with the final value
 	fmt.Printf("\033[1A\033[2KRemote                     %s\n", remote)
 
-	// Most recent fetch
-	fmt.Printf("Most recent fetch          ... fetching\n")
-	recentFetch := git.GetLastFetchTime()
-	fmt.Printf("\033[1A\033[2KMost recent fetch          %s\n", recentFetch)
+	recentUpdate := UnknownValue
+	recentFetch := UnknownValue
+	if isBare {
+		fmt.Printf("Most recent update         ... fetching\n")
+		recentUpdate = git.GetLastUpdateTime()
+		fmt.Printf("\033[1A\033[2KMost recent update         %s\n", recentUpdate)
+	} else {
+		fmt.Printf("Most recent fetch          ... fetching\n")
+		recentFetch = git.GetLastFetchTime()
+		fmt.Printf("\033[1A\033[2KMost recent fetch          %s\n", recentFetch)
+	}
 
 	// Most recent commit
 	fmt.Printf("Most recent commit         ... fetching\n")
@@ -206,6 +216,7 @@ func main() {
 	// Save repository information with totals
 	repositoryInformation := models.RepositoryInformation{
 		Remote:         remote,
+		IsBare:         isBare,
 		LastCommit:     lastCommit,
 		FirstCommit:    firstCommit,
 		Age:            ageString,
@@ -243,7 +254,11 @@ func main() {
 
 		fmt.Println("------------------------------------------------------------------------------------------------")
 		fmt.Println()
-		fmt.Printf("^ Current totals as of the last fetch on %s\n", recentFetch[:11])
+		if isBare {
+			fmt.Printf("^ Current totals as of the most recent update on %s\n", recentUpdate[:11])
+		} else {
+			fmt.Printf("^ Current totals as of the most recent fetch on %s\n", recentFetch[:11])
+		}
 		fmt.Println("* Estimated growth based on the last five years")
 		fmt.Println("% Percentages show the increase relative to the current total (^)")
 	} else {

--- a/main.go
+++ b/main.go
@@ -77,9 +77,6 @@ func main() {
 		fmt.Printf("Last modified              %s\n", lastModified)
 	}
 
-	// Check if repository is bare
-	isBare := git.IsBareRepository(".")
-
 	// Remote URL - only show if there is one
 	remoteOutput, err := git.RunGitCommand(debug, "remote", "get-url", "origin")
 	remote := ""
@@ -226,7 +223,6 @@ func main() {
 	// Save repository information with totals
 	repositoryInformation := models.RepositoryInformation{
 		Remote:         remote,
-		IsBare:         isBare,
 		LastCommit:     lastCommit,
 		FirstCommit:    firstCommit,
 		Age:            ageString,

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -113,10 +113,23 @@ func GetLastUpdateTime() string {
 	return "Unknown"
 }
 
-// GetLastFetchTime returns the time of the last git fetch or repo update for bare repos
-// Deprecated: Use GetLastUpdateTime instead
+// GetLastFetchTime returns the time of the last git fetch by checking FETCH_HEAD
 func GetLastFetchTime() string {
-	return GetLastUpdateTime()
+	// Get Git directory path
+	gitDirOutput, err := RunGitCommand(false, "rev-parse", "--git-dir")
+	if err != nil {
+		return ""
+	}
+
+	gitDir := strings.TrimSpace(string(gitDirOutput))
+	fetchHead := filepath.Join(gitDir, "FETCH_HEAD")
+
+	// Check if FETCH_HEAD exists
+	if fetchInformation, err := os.Stat(fetchHead); err == nil {
+		return fetchInformation.ModTime().Format("Mon, 02 Jan 2006 15:04 MST")
+	}
+
+	return ""
 }
 
 // GetGrowthStats calculates repository growth statistics for a given year

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -114,14 +114,7 @@ func GetLastUpdateTime() string {
 }
 
 // GetLastFetchTime returns the time of the last git fetch by checking FETCH_HEAD
-func GetLastFetchTime() string {
-	// Get Git directory path
-	gitDirOutput, err := RunGitCommand(false, "rev-parse", "--git-dir")
-	if err != nil {
-		return ""
-	}
-
-	gitDir := strings.TrimSpace(string(gitDirOutput))
+func GetLastFetchTime(gitDir string) string {
 	fetchHead := filepath.Join(gitDir, "FETCH_HEAD")
 
 	// Check if FETCH_HEAD exists

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -110,6 +110,20 @@ func TestGetGitDirectory(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			name: "Valid bare repository",
+			setupFunc: func() string {
+				// Create a temporary directory and initialize a bare repo in it
+				tempDir, _ := os.MkdirTemp("", "git-repo-bare")
+				cmd := exec.Command("git", "init", "--bare", tempDir)
+				cmd.Run()
+				return tempDir
+			},
+			cleanupFunc: func(path string) {
+				os.RemoveAll(path)
+			},
+			wantErr: false,
+		},
 	}
 
 	for _, tt := range tests {

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -2,74 +2,12 @@ package git
 
 import (
 	"os"
-	"path/filepath"
+	"os/exec"
 	"strings"
 	"testing"
 
 	"git-metrics/pkg/models"
 )
-
-func TestValidateRepository(t *testing.T) {
-	tests := []struct {
-		name        string
-		path        string
-		setupFunc   func() string
-		cleanupFunc func(string)
-		wantErr     bool
-	}{
-		{
-			name:    "Non-existent path",
-			path:    "/path/does/not/exist",
-			wantErr: true,
-		},
-		{
-			name: "Path exists but not a git repository",
-			setupFunc: func() string {
-				// Create a temporary directory
-				tempDir, _ := os.MkdirTemp("", "not-git-repo")
-				return tempDir
-			},
-			cleanupFunc: func(path string) {
-				os.RemoveAll(path)
-			},
-			wantErr: true,
-		},
-		{
-			name: "Valid git repository",
-			setupFunc: func() string {
-				// Create a temporary directory and initialize a git repo in it
-				tempDir, _ := os.MkdirTemp("", "git-repo")
-				os.Mkdir(filepath.Join(tempDir, ".git"), 0755)
-				return tempDir
-			},
-			cleanupFunc: func(path string) {
-				os.RemoveAll(path)
-			},
-			wantErr: false,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			var path string
-			if tt.setupFunc != nil {
-				path = tt.setupFunc()
-				if tt.path == "" {
-					tt.path = path
-				}
-			}
-
-			if tt.cleanupFunc != nil && path != "" {
-				defer tt.cleanupFunc(path)
-			}
-
-			err := ValidateRepository(tt.path)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("ValidateRepository() error = %v, wantErr %v", err, tt.wantErr)
-			}
-		})
-	}
-}
 
 func TestCalculateEstimate(t *testing.T) {
 	current := models.GrowthStatistics{
@@ -130,6 +68,76 @@ func TestGetGitVersion(t *testing.T) {
 	// Basic format check - shouldn't contain "git version" prefix since that's stripped
 	if strings.Contains(version, "git version") {
 		t.Errorf("GetGitVersion() = %q, should not contain 'git version' prefix", version)
+	}
+}
+
+func TestGetGitDirectory(t *testing.T) {
+	tests := []struct {
+		name        string
+		path        string
+		setupFunc   func() string
+		cleanupFunc func(string)
+		wantErr     bool
+	}{
+		{
+			name:    "Non-existent path",
+			path:    "/path/does/not/exist",
+			wantErr: true,
+		},
+		{
+			name: "Path exists but not a git repository",
+			setupFunc: func() string {
+				// Create a temporary directory
+				tempDir, _ := os.MkdirTemp("", "not-git-repo")
+				return tempDir
+			},
+			cleanupFunc: func(path string) {
+				os.RemoveAll(path)
+			},
+			wantErr: true,
+		},
+		{
+			name: "Valid git repository",
+			setupFunc: func() string {
+				// Create a temporary directory and initialize a git repo in it
+				tempDir, _ := os.MkdirTemp("", "git-repo")
+				cmd := exec.Command("git", "init", tempDir)
+				cmd.Run()
+				return tempDir
+			},
+			cleanupFunc: func(path string) {
+				os.RemoveAll(path)
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var path string
+			if tt.setupFunc != nil {
+				path = tt.setupFunc()
+				if tt.path == "" {
+					tt.path = path
+				}
+			}
+
+			if tt.cleanupFunc != nil && path != "" {
+				defer tt.cleanupFunc(path)
+			}
+
+			gitDir, err := GetGitDirectory(tt.path)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GetGitDirectory() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if err == nil {
+				// If no error, verify that the path exists and is a git directory
+				if _, err := os.Stat(gitDir); err != nil {
+					t.Errorf("GetGitDirectory() returned path %v that does not exist", gitDir)
+				}
+			}
+		})
 	}
 }
 

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -13,7 +13,6 @@ type RepositoryInformation struct {
 	TotalTrees     int
 	TotalBlobs     int
 	CompressedSize int64
-	IsBare         bool
 }
 
 // GrowthStatistics holds statistics about repository growth

--- a/pkg/models/models.go
+++ b/pkg/models/models.go
@@ -13,6 +13,7 @@ type RepositoryInformation struct {
 	TotalTrees     int
 	TotalBlobs     int
 	CompressedSize int64
+	IsBare         bool
 }
 
 // GrowthStatistics holds statistics about repository growth


### PR DESCRIPTION
Resolves #12

Regarding last modified and most recent fetch timestamps that are shown in the output, we want to cover these scenarios:

1. **Fresh new non-bare clone** (show "Last modified" of Git directory, since no `FETCH_HEAD` exists)
2. **After a fetch within a non-bare clone** (show "Most recent fetch" based on last modified of `FETCH_HEAD`)
3. **Fresh new bare clone** (show "Last modified" of Git directory, since no `FETCH_HEAD` exists)
4. **After a fetch within a bare clone** (show "Last modified" of Git directory, since no `FETCH_HEAD` exists)
5. **Running on the server side of a Git hosting server** (show "Last modified" of Git directory, since `FETCH_HEAD` will usually never exist)