### PR TITLE
Add terminal client detection to the RUN section

### DIFF
--- a/pkg/display/sections/run_information.go
+++ b/pkg/display/sections/run_information.go
@@ -18,6 +18,7 @@ func DisplayRunInformation() {
 		utils.GetMemoryInGigabytes(),
 		utils.GetOperatingSystemInformation(),
 		utils.GetChipInformation())
+	fmt.Printf("Terminal                   %s\n", utils.GetTerminalInformation())
 	fmt.Printf("Git metrics version        %s\n", utils.GetGitMetricsVersion())
 	fmt.Printf("Git version                %s\n", git.GetGitVersion())
 }

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -4,10 +4,13 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strconv"
 	"strings"
 	"time"
+
+	"golang.org/x/term"
 )
 
 // GetConcernLevel returns the Level of Concern symbol based on the metric type and value
@@ -345,3 +348,79 @@ func IsTerminal(file *os.File) bool {
 	}
 	return false
 }
+
+// GetTerminalInformation returns information about the terminal client.
+// It detects the terminal program, version, TERM type, shell, and terminal
+// dimensions to help diagnose rendering issues when users share reports.
+func GetTerminalInformation() string {
+	// Detect terminal program from environment variables
+	terminalProgram := os.Getenv("TERM_PROGRAM")
+	terminalVersion := os.Getenv("TERM_PROGRAM_VERSION")
+
+	// Fall back to LC_TERMINAL (set by some terminals over SSH)
+	if terminalProgram == "" {
+		terminalProgram = os.Getenv("LC_TERMINAL")
+		terminalVersion = os.Getenv("LC_TERMINAL_VERSION")
+	}
+
+	// Detect Windows Terminal
+	if terminalProgram == "" && os.Getenv("WT_SESSION") != "" {
+		terminalProgram = "Windows Terminal"
+	}
+
+	// Build the primary identifier (program name and version)
+	var primaryIdentifier string
+	if terminalProgram != "" {
+		if terminalVersion != "" {
+			primaryIdentifier = fmt.Sprintf("%s %s", terminalProgram, terminalVersion)
+		} else {
+			primaryIdentifier = terminalProgram
+		}
+	}
+
+	// Collect detail parts for parenthetical info
+	var details []string
+
+	// Add TERM type
+	termType := os.Getenv("TERM")
+	if termType != "" {
+		details = append(details, termType)
+	}
+
+	// Add color support level
+	colorTerm := os.Getenv("COLORTERM")
+	if colorTerm != "" {
+		details = append(details, colorTerm)
+	}
+
+	// Add shell name
+	shell := os.Getenv("SHELL")
+	if shell != "" {
+		details = append(details, filepath.Base(shell))
+	}
+
+	// Add terminal dimensions if available
+	width, height, err := term.GetSize(int(os.Stdout.Fd()))
+	if err == nil && width > 0 && height > 0 {
+		details = append(details, fmt.Sprintf("%d×%d", width, height))
+	}
+
+	// Build final string
+	detailString := ""
+	if len(details) > 0 {
+		detailString = fmt.Sprintf("(%s)", strings.Join(details, ", "))
+	}
+
+	if primaryIdentifier != "" && detailString != "" {
+		return fmt.Sprintf("%s %s", primaryIdentifier, detailString)
+	}
+	if primaryIdentifier != "" {
+		return primaryIdentifier
+	}
+	if detailString != "" {
+		return detailString
+	}
+
+	return "Unknown"
+}
+

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -366,3 +366,87 @@ func TestIsTerminal(t *testing.T) {
 		t.Error("Mocked stderr incorrectly identified as a terminal")
 	}
 }
+
+func TestGetTerminalInformationReturnsNonEmpty(t *testing.T) {
+	// GetTerminalInformation should always return a non-empty string
+	result := GetTerminalInformation()
+	if result == "" {
+		t.Error("Expected non-empty terminal information")
+	}
+}
+
+func TestGetTerminalInformationWithTermProgram(t *testing.T) {
+	// Save and restore environment variables
+	originalTermProgram := os.Getenv("TERM_PROGRAM")
+	originalTermProgramVersion := os.Getenv("TERM_PROGRAM_VERSION")
+	defer func() {
+		os.Setenv("TERM_PROGRAM", originalTermProgram)
+		os.Setenv("TERM_PROGRAM_VERSION", originalTermProgramVersion)
+	}()
+
+	os.Setenv("TERM_PROGRAM", "TestTerminal")
+	os.Setenv("TERM_PROGRAM_VERSION", "1.2.3")
+
+	result := GetTerminalInformation()
+	if result == "" {
+		t.Error("Expected non-empty terminal information")
+	}
+	if !contains(result, "TestTerminal") {
+		t.Errorf("Expected terminal information to contain 'TestTerminal', got: %s", result)
+	}
+	if !contains(result, "1.2.3") {
+		t.Errorf("Expected terminal information to contain '1.2.3', got: %s", result)
+	}
+}
+
+func TestGetTerminalInformationFallsBackToUnknown(t *testing.T) {
+	// Save and restore environment variables
+	originalTermProgram := os.Getenv("TERM_PROGRAM")
+	originalTermProgramVersion := os.Getenv("TERM_PROGRAM_VERSION")
+	originalLcTerminal := os.Getenv("LC_TERMINAL")
+	originalLcTerminalVersion := os.Getenv("LC_TERMINAL_VERSION")
+	originalWtSession := os.Getenv("WT_SESSION")
+	originalTerm := os.Getenv("TERM")
+	originalColorTerm := os.Getenv("COLORTERM")
+	originalShell := os.Getenv("SHELL")
+	defer func() {
+		os.Setenv("TERM_PROGRAM", originalTermProgram)
+		os.Setenv("TERM_PROGRAM_VERSION", originalTermProgramVersion)
+		os.Setenv("LC_TERMINAL", originalLcTerminal)
+		os.Setenv("LC_TERMINAL_VERSION", originalLcTerminalVersion)
+		os.Setenv("WT_SESSION", originalWtSession)
+		os.Setenv("TERM", originalTerm)
+		os.Setenv("COLORTERM", originalColorTerm)
+		os.Setenv("SHELL", originalShell)
+	}()
+
+	// Clear all terminal-related environment variables
+	os.Unsetenv("TERM_PROGRAM")
+	os.Unsetenv("TERM_PROGRAM_VERSION")
+	os.Unsetenv("LC_TERMINAL")
+	os.Unsetenv("LC_TERMINAL_VERSION")
+	os.Unsetenv("WT_SESSION")
+	os.Unsetenv("TERM")
+	os.Unsetenv("COLORTERM")
+	os.Unsetenv("SHELL")
+
+	result := GetTerminalInformation()
+	if result == "" {
+		t.Error("Expected non-empty terminal information even with no env vars")
+	}
+}
+
+func contains(haystack, needle string) bool {
+	return len(haystack) >= len(needle) && (haystack == needle || len(needle) == 0 ||
+		(len(haystack) > 0 && len(needle) > 0 && stringContains(haystack, needle)))
+}
+
+func stringContains(haystack, needle string) bool {
+	for i := 0; i <= len(haystack)-len(needle); i++ {
+		if haystack[i:i+len(needle)] == needle {
+			return true
+		}
+	}
+	return false
+}
+

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -2,6 +2,7 @@ package utils
 
 import (
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -376,77 +377,32 @@ func TestGetTerminalInformationReturnsNonEmpty(t *testing.T) {
 }
 
 func TestGetTerminalInformationWithTermProgram(t *testing.T) {
-	// Save and restore environment variables
-	originalTermProgram := os.Getenv("TERM_PROGRAM")
-	originalTermProgramVersion := os.Getenv("TERM_PROGRAM_VERSION")
-	defer func() {
-		os.Setenv("TERM_PROGRAM", originalTermProgram)
-		os.Setenv("TERM_PROGRAM_VERSION", originalTermProgramVersion)
-	}()
-
-	os.Setenv("TERM_PROGRAM", "TestTerminal")
-	os.Setenv("TERM_PROGRAM_VERSION", "1.2.3")
+	t.Setenv("TERM_PROGRAM", "TestTerminal")
+	t.Setenv("TERM_PROGRAM_VERSION", "1.2.3")
 
 	result := GetTerminalInformation()
-	if result == "" {
-		t.Error("Expected non-empty terminal information")
-	}
-	if !contains(result, "TestTerminal") {
+	if !strings.Contains(result, "TestTerminal") {
 		t.Errorf("Expected terminal information to contain 'TestTerminal', got: %s", result)
 	}
-	if !contains(result, "1.2.3") {
+	if !strings.Contains(result, "1.2.3") {
 		t.Errorf("Expected terminal information to contain '1.2.3', got: %s", result)
 	}
 }
 
 func TestGetTerminalInformationFallsBackToUnknown(t *testing.T) {
-	// Save and restore environment variables
-	originalTermProgram := os.Getenv("TERM_PROGRAM")
-	originalTermProgramVersion := os.Getenv("TERM_PROGRAM_VERSION")
-	originalLcTerminal := os.Getenv("LC_TERMINAL")
-	originalLcTerminalVersion := os.Getenv("LC_TERMINAL_VERSION")
-	originalWtSession := os.Getenv("WT_SESSION")
-	originalTerm := os.Getenv("TERM")
-	originalColorTerm := os.Getenv("COLORTERM")
-	originalShell := os.Getenv("SHELL")
-	defer func() {
-		os.Setenv("TERM_PROGRAM", originalTermProgram)
-		os.Setenv("TERM_PROGRAM_VERSION", originalTermProgramVersion)
-		os.Setenv("LC_TERMINAL", originalLcTerminal)
-		os.Setenv("LC_TERMINAL_VERSION", originalLcTerminalVersion)
-		os.Setenv("WT_SESSION", originalWtSession)
-		os.Setenv("TERM", originalTerm)
-		os.Setenv("COLORTERM", originalColorTerm)
-		os.Setenv("SHELL", originalShell)
-	}()
-
 	// Clear all terminal-related environment variables
-	os.Unsetenv("TERM_PROGRAM")
-	os.Unsetenv("TERM_PROGRAM_VERSION")
-	os.Unsetenv("LC_TERMINAL")
-	os.Unsetenv("LC_TERMINAL_VERSION")
-	os.Unsetenv("WT_SESSION")
-	os.Unsetenv("TERM")
-	os.Unsetenv("COLORTERM")
-	os.Unsetenv("SHELL")
+	t.Setenv("TERM_PROGRAM", "")
+	t.Setenv("TERM_PROGRAM_VERSION", "")
+	t.Setenv("LC_TERMINAL", "")
+	t.Setenv("LC_TERMINAL_VERSION", "")
+	t.Setenv("WT_SESSION", "")
+	t.Setenv("TERM", "")
+	t.Setenv("COLORTERM", "")
+	t.Setenv("SHELL", "")
 
 	result := GetTerminalInformation()
-	if result == "" {
-		t.Error("Expected non-empty terminal information even with no env vars")
+	if result != "Unknown" {
+		t.Errorf("Expected 'Unknown' when all terminal env vars are unset, got: %s", result)
 	}
-}
-
-func contains(haystack, needle string) bool {
-	return len(haystack) >= len(needle) && (haystack == needle || len(needle) == 0 ||
-		(len(haystack) > 0 && len(needle) > 0 && stringContains(haystack, needle)))
-}
-
-func stringContains(haystack, needle string) bool {
-	for i := 0; i <= len(haystack)-len(needle); i++ {
-		if haystack[i:i+len(needle)] == needle {
-			return true
-		}
-	}
-	return false
 }
 

--- a/script/remove-non-deterministic-rows
+++ b/script/remove-non-deterministic-rows
@@ -28,6 +28,7 @@ pattern_file="$(mktemp)"
 cat > "$pattern_file" <<EOF
 ^Start time
 ^Machine
+^Terminal
 ^Git version
 ^Git directory
 ^Last modified


### PR DESCRIPTION
## Summary

Display the terminal client information in the RUN section of the report to help diagnose rendering issues when users share reports. Terminal emulators differ significantly in ANSI escape sequence support, unicode rendering, and color depth, so knowing the terminal makes it much easier to reproduce and fix display problems.

## Changes

### `pkg/utils/utils.go` — `GetTerminalInformation()`
Detects the terminal client by checking the following environment variables in order:
- **`TERM_PROGRAM`** + **`TERM_PROGRAM_VERSION`** — set by most terminal emulators (iTerm2, Apple Terminal, VSCode, WarpTerminal, Ghostty, Alacritty, etc.)
- **`LC_TERMINAL`** + **`LC_TERMINAL_VERSION`** — fallback for SSH sessions (iTerm2 propagates these)
- **`WT_SESSION`** — Windows Terminal detection

Supplementary details shown in parentheses:
- `TERM` type (e.g. `xterm-256color`)
- `COLORTERM` color support level (e.g. `truecolor`)
- Shell name (basename of `SHELL`)
- Terminal dimensions via `golang.org/x/term` (e.g. `120×30`)

Falls back to `"Unknown"` when no terminal information is available.

**Example output:**
```
Terminal                   iTerm2 3.5.10 (xterm-256color, truecolor, zsh, 120×30)
```

### `pkg/display/sections/run_information.go`
Added `Terminal` line between `Machine` and `Git metrics version`.

### `script/remove-non-deterministic-rows`
Added `^Terminal` to the integration test filter since the value varies across environments.

### `pkg/utils/utils_test.go`
Added 3 tests:
- `TestGetTerminalInformationReturnsNonEmpty`
- `TestGetTerminalInformationWithTermProgram`
- `TestGetTerminalInformationFallsBackToUnknown`